### PR TITLE
chore: agregando archivos para ignorar y limpieza en error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 environment.staging.ts
 environment.local.ts
 .env
-.env.development
+.env.staging
+.env.prod
+.infisical.json
 /src/environments
 
 # Compiled output

--- a/src/app/pagos/pages/pagos/pagos.component.ts
+++ b/src/app/pagos/pages/pagos/pagos.component.ts
@@ -174,6 +174,8 @@ export class PagosComponent implements OnInit {
   }
 
   errorEnDatosDelFolio(err: unknown): void {
+    this.prestamosDetalle = [];
+    this.prestamo = undefined;
     console.log(err);
     this.messageService.add({
       severity: 'error',


### PR DESCRIPTION
- Se agregaron archivos importantes con el contenido de las variables de entorno y evitar que lleguen al repositorio de GH
- Limpieza añadida cuando el back regrese un error y ya se tuvieran datos en pantalla de un folio previo, evitando asi la manipulacion del folio previo y evitar problemas futuros a los usuarios