### PR TITLE
style: corrigiendo path de purgecss.conf para que funcione en linux

### DIFF
--- a/purgecss.config.js
+++ b/purgecss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   content: ['dist/**/index.html', 'dist/**/*.js'],
   css: ['dist/**/*.css'],
-  output: '.',
+  output: 'dist/yoox-web-app/browser/',
   safelist: {
     standard: [
       // Agrega aquí otros patrones de PrimeFlex que necesites


### PR DESCRIPTION
la ruta de output no funcionaba correctamente en sistemas basados en unix, pero si en sistemas windows, fue hecha la correccion para que funcionara el script de purgecss en los sistemas de CI de cloudflare y netlify