### PR TITLE
chore: cambiando a ES2022 para aumentar compatibilidad con navegadores

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,11 +16,16 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "importHelpers": true,
-    "target": "ESNext",
-    "module": "ESNext",
+    "target": "ES2022",
+    "module": "ES2022",
     "useDefineForClassFields": false,
-    "lib": ["ESNext", "dom"],
-    "types": ["node"]
+    "lib": [
+      "ES2022",
+      "dom"
+    ],
+    "types": [
+      "node"
+    ]
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
simple cambio para permitir a navegadores un poco desactualizados poder ejecutar los diferentes comportamientos de javascript y hacer que la app no se rompa tan facil por usar un navegador no tan nuevo