### PR TITLE
feat: limitando approvers

### DIFF
--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -943,6 +943,7 @@
                 (onClick)="updateProvitionalStatus('ACTUALIZAR')"
                 severity="warning"></p-button>
               <p-button
+                *ngIf="currentUser?.ROL !== 'Líder de grupo'"
                 pTooltip="Se acepta la solicitud y se genera el prestamo de manera automatica."
                 tooltipPosition="bottom"
                 [hidden]="status === 'ACTUALIZAR'"


### PR DESCRIPTION
antes solo los usuarios que no fueran cobrador podian aprovar, ahora solo los unicos que pueden aprovar son solo los Administradores y los usuarios normales