### PR TITLE
Validaciones curp telefonos

### DIFF
--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -260,6 +260,7 @@
           <div class="col-12 sm:col-6 flex flex-column">
             <label for="telefono_fijo_cliente">Telefono fijo</label>
             <p-inputMask
+              (onFocus)="restartPhonesValidator('formCliente', 'telefono_fijo_cliente')"
               formControlName="telefono_fijo_cliente"
               inputId="telefono_fijo_cliente"
               mask="999-999-9999"
@@ -280,7 +281,7 @@
                 ]
               ) {
                 <ng-container
-                  >Numero telefonico fijo de cliente existente</ng-container
+                  > Numero telefonico fijo de cliente existente</ng-container
                 >
               }
             </small>
@@ -288,6 +289,7 @@
           <div class="col-12 sm:col-6 flex flex-column">
             <label for="telefono_movil_cliente">Telefono movil</label>
             <p-inputMask
+              (onFocus)="restartPhonesValidator('formCliente', 'telefono_movil_cliente')"
               formControlName="telefono_movil_cliente"
               inputId="telefono_movil_cliente"
               mask="999-999-9999"
@@ -308,7 +310,7 @@
                 ]
               ) {
                 <ng-container
-                  >Numero telefonico movil de cliente existente</ng-container
+                  > Numero telefonico movil de cliente existente</ng-container
                 >
               }
             </small>
@@ -338,6 +340,7 @@
           <div class="col-12 sm:col-6 flex flex-column">
             <label for="curp_cliente">CURP (Sólo Mayusculas y numeros)</label>
             <p-inputMask
+              (onFocus)="restartCurpValidator('formCliente', 'curp_cliente')"
               mask="aaaa-999999-aaaaaa-99"
               inputId="curp_cliente"
               characterPattern="[A-Z]"
@@ -619,6 +622,7 @@
             <div class="col-12 sm:col-6 flex flex-column">
               <label for="telefono_fijo_aval">Telefono fijo</label>
               <p-inputMask
+              (onFocus)="restartPhonesValidator('formAval', 'telefono_fijo_aval')"
                 formControlName="telefono_fijo_aval"
                 inputId="telefono_fijo_aval"
                 mask="999-999-9999"
@@ -637,7 +641,7 @@
                   ]
                 ) {
                   <ng-container
-                    >Numero telefónico fijo de aval existente</ng-container
+                    > Numero telefónico fijo de aval existente</ng-container
                   >
                 }
               </small>
@@ -645,6 +649,7 @@
             <div class="col-12 sm:col-6 flex flex-column">
               <label for="telefono_movil_aval">Telefono movil</label>
               <p-inputMask
+                (onFocus)="restartPhonesValidator('formAval', 'telefono_movil_aval')"
                 formControlName="telefono_movil_aval"
                 inputId="telefono_movil_aval"
                 mask="999-999-9999"
@@ -664,7 +669,7 @@
                   ]
                 ) {
                   <ng-container
-                    >Numero telefónico movil de aval existente</ng-container
+                    > Numero telefónico movil de aval existente</ng-container
                   >
                 }
               </small>
@@ -686,6 +691,8 @@
             <div class="col-12 sm:col-6 flex flex-column">
               <label for="curp_aval">CURP (Sólo Mayusculas y numeros)</label>
               <p-inputMask
+                #curp_aval
+                (onFocus)="restartCurpValidator('formAval','curp_aval')"
                 mask="aaaa-999999-aaaaaa-99"
                 inputId="curp_aval"
                 characterPattern="[A-Z]"

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -102,8 +102,8 @@ export class LoanComponent implements OnDestroy, OnInit {
   pagoSemanal: number | null = null;
   uploading = false;
   uploadSuccessfull = false;
-  id_cliente_recuperado = 0;
-  id_aval_recuperado = 0;
+  id_cliente_recuperado?: number;
+  id_aval_recuperado?: number;
   showLoadingModal = false;
   viewLoan: any;
   observationsHistory = '';
@@ -166,7 +166,7 @@ export class LoanComponent implements OnDestroy, OnInit {
 
     if (this.windowMode === 'view') {
       this.showLoadingModal = true;
-      this.clearAsyncValidators();
+      // this.clearAsyncValidators();
       this.fillFormForViewMode();
     }
   }
@@ -188,41 +188,11 @@ export class LoanComponent implements OnDestroy, OnInit {
           nombre_cliente: ['', Validators.required],
           apellido_paterno_cliente: ['', Validators.required],
           apellido_materno_cliente: ['', Validators.required],
-          telefono_fijo_cliente: [
-            '',
-            {
-              asyncValidators: existingPhonesAsyncValidator(
-                this.#validatorPhonesService,
-                'CLIENTES',
-                'telefono_fijo'
-              ),
-              updateOn: 'blur',
-            },
-          ],
-          telefono_movil_cliente: [
-            '',
-            {
-              asyncValidators: existingPhonesAsyncValidator(
-                this.#validatorPhonesService,
-                'CLIENTES',
-                'telefono_movil'
-              ),
-              updateOn: 'blur',
-            },
-          ],
+          telefono_fijo_cliente: [''],
+          telefono_movil_cliente: [''],
           correo_electronico_cliente: ['', emailValidator()],
           ocupacion_cliente: [''],
-          curp_cliente: [
-            '',
-            {
-              validators: [Validators.required, curpValidator()],
-              asyncValidators: existingCurpAsyncValidator(
-                this.#validatorCurpService,
-                'CLIENTES'
-              ),
-              updateOn: 'blur',
-            },
-          ],
+          curp_cliente: ['', [Validators.required, curpValidator()]],
           id_domicilio_cliente: [],
           tipo_calle_cliente: ['', Validators.required],
           nombre_calle_cliente: ['', Validators.required],
@@ -248,40 +218,10 @@ export class LoanComponent implements OnDestroy, OnInit {
           nombre_aval: ['', Validators.required],
           apellido_paterno_aval: ['', Validators.required],
           apellido_materno_aval: ['', Validators.required],
-          telefono_fijo_aval: [
-            '',
-            {
-              asyncValidators: existingPhonesAsyncValidator(
-                this.#validatorPhonesService,
-                'AVALES',
-                'telefono_fijo'
-              ),
-              updateOn: 'blur',
-            },
-          ],
-          telefono_movil_aval: [
-            '',
-            {
-              asyncValidators: existingPhonesAsyncValidator(
-                this.#validatorPhonesService,
-                'AVALES',
-                'telefono_movil'
-              ),
-              updateOn: 'blur',
-            },
-          ],
+          telefono_fijo_aval: [''],
+          telefono_movil_aval: [''],
           correo_electronico_aval: ['', emailValidator()],
-          curp_aval: [
-            '',
-            {
-              validators: [Validators.required, curpValidator()],
-              asyncValidators: existingCurpAsyncValidator(
-                this.#validatorCurpService,
-                'AVALES'
-              ),
-              updateOn: 'blur',
-            },
-          ],
+          curp_aval: ['', [Validators.required, curpValidator()]],
           id_domicilio_aval: [],
           tipo_calle_aval: ['', Validators.required],
           nombre_calle_aval: ['', Validators.required],
@@ -624,22 +564,6 @@ export class LoanComponent implements OnDestroy, OnInit {
   toggleCustomerSearch() {
     this.customerSearchVisible = !this.customerSearchVisible;
     this.switchBusqueda()?.writeValue(this.customerSearchVisible);
-    if (this.id_cliente_recuperado) {
-      this.clearAsyncValidators();
-    } else {
-      this.mainForm
-        .get('formCliente.curp_cliente')
-        ?.setAsyncValidators(
-          existingCurpAsyncValidator(this.#validatorCurpService, 'CLIENTES')
-        );
-      this.mainForm
-        .get('formAval.curp_aval')
-        ?.setAsyncValidators(
-          existingCurpAsyncValidator(this.#validatorCurpService, 'AVALES')
-        );
-
-      this.mainForm.updateValueAndValidity();
-    }
   }
 
   /**
@@ -658,36 +582,6 @@ export class LoanComponent implements OnDestroy, OnInit {
         id_domicilio_aval: idsRecuperados.id_domicilio_aval,
       },
     });
-  }
-
-  /** Encargada de eliminar los validadores asincronos cuando no se necesitan, solo son requedidos en modo new, en los demas modos no se necesitan */
-  clearAsyncValidators() {
-    const form_curp_cliente = this.mainForm.get('formCliente.curp_cliente');
-    const form_curp_aval = this.mainForm.get('formAval.curp_aval');
-    const form_telefono_movil_cliente = this.mainForm.get(
-      'formCliente.telefono_movil_cliente'
-    );
-    const form_telefono_fijo_cliente = this.mainForm.get(
-      'formCliente.telefono_fijo_cliente'
-    );
-    const form_telefono_movil_aval = this.mainForm.get(
-      'formAval.telefono_movil_aval'
-    );
-    const form_telefono_fijo_aval = this.mainForm.get(
-      'formAval.telefono_fijo_aval'
-    );
-    form_curp_cliente?.clearAsyncValidators();
-    form_curp_cliente?.updateValueAndValidity();
-    form_curp_aval?.clearAsyncValidators();
-    form_curp_aval?.updateValueAndValidity();
-    form_telefono_movil_cliente?.clearAsyncValidators();
-    form_telefono_movil_cliente?.updateValueAndValidity();
-    form_telefono_fijo_cliente?.clearAsyncValidators();
-    form_telefono_fijo_cliente?.updateValueAndValidity();
-    form_telefono_movil_aval?.clearAsyncValidators();
-    form_telefono_movil_aval?.updateValueAndValidity();
-    form_telefono_fijo_aval?.clearAsyncValidators();
-    form_telefono_fijo_aval?.updateValueAndValidity();
   }
 
   /**
@@ -750,6 +644,9 @@ export class LoanComponent implements OnDestroy, OnInit {
             (plazo) => plazo.id === data.id_plazo
           )?.semanas_refinancia;
           this.observationsHistory = data.observaciones;
+          this.id_cliente_recuperado = data.id_cliente || undefined;
+          this.id_aval_recuperado = data.id_aval || undefined;
+          this.mainForm = this.formInit();
           this.mainForm.patchValue({
             cantidad_prestada: data.cantidad_prestada,
             plazo: plazos.find((plazo) => plazo.id === data.id_plazo),
@@ -939,5 +836,43 @@ export class LoanComponent implements OnDestroy, OnInit {
         });
         break;
     }
+  }
+
+  restartCurpValidator(form: string, input: string) {
+    const path = `${form}.${input}`;
+    const formInput = this.mainForm.get(path);
+    const table = form.includes('formCliente') ? 'CLIENTES' : 'AVALES';
+    const id =
+      table == 'CLIENTES'
+        ? this.id_cliente_recuperado
+        : this.id_aval_recuperado;
+    // formInput?.clearAsyncValidators();
+    formInput?.setAsyncValidators(
+      existingCurpAsyncValidator(this.#validatorCurpService, table, id)
+    );
+    formInput?.updateValueAndValidity();
+  }
+
+  restartPhonesValidator(form: string, formControlName: string) {
+    const path = `${form}.${formControlName}`;
+    const formInput = this.mainForm.get(path);
+    const table = form.includes('formCliente') ? 'CLIENTES' : 'AVALES';
+    const tipo_telefono = formControlName.includes('fijo')
+      ? 'telefono_fijo'
+      : 'telefono_movil';
+    const id =
+      table == 'CLIENTES'
+        ? this.id_cliente_recuperado
+        : this.id_aval_recuperado;
+    // formInput?.clearAsyncValidators();
+    formInput?.setAsyncValidators(
+      existingPhonesAsyncValidator(
+        this.#validatorPhonesService,
+        table,
+        tipo_telefono,
+        id
+      )
+    );
+    formInput?.updateValueAndValidity();
   }
 }

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -846,7 +846,6 @@ export class LoanComponent implements OnDestroy, OnInit {
       table == 'CLIENTES'
         ? this.id_cliente_recuperado
         : this.id_aval_recuperado;
-    // formInput?.clearAsyncValidators();
     formInput?.setAsyncValidators(
       existingCurpAsyncValidator(this.#validatorCurpService, table, id)
     );
@@ -864,7 +863,6 @@ export class LoanComponent implements OnDestroy, OnInit {
       table == 'CLIENTES'
         ? this.id_cliente_recuperado
         : this.id_aval_recuperado;
-    // formInput?.clearAsyncValidators();
     formInput?.setAsyncValidators(
       existingPhonesAsyncValidator(
         this.#validatorPhonesService,

--- a/src/app/loan-request/services/validacion-curp.service.ts
+++ b/src/app/loan-request/services/validacion-curp.service.ts
@@ -11,6 +11,7 @@ export class ExistingCurpValidationService {
     const token = localStorage.getItem('token');
     if (!token) throw new Error('Token not found');
 
+    // TODO: considerar cambiar a un metodo get en lugar de post
     return this.#http.post(`${this.#baseUrl}validate/curp`, body, {
       headers: { authorization: `${token}` },
     });

--- a/src/app/loan-request/services/validacion-telefonos.service.ts
+++ b/src/app/loan-request/services/validacion-telefonos.service.ts
@@ -11,6 +11,7 @@ export class ValidatorExistingPhoneService {
     const token = localStorage.getItem('token');
     if (!token) throw new Error('Token not found');
 
+    // TODO: considerar cambiar a un metodo get en lugar de post
     return this.#http.post(`${this.#baseUrl}validate/phones`, body, {
       headers: { authorization: `${token}` },
     });

--- a/src/app/loan-request/utils/customValidators.ts
+++ b/src/app/loan-request/utils/customValidators.ts
@@ -60,7 +60,8 @@ export function atLeastOneValidator(controlNames: string[]): ValidatorFn {
 
 export function existingCurpAsyncValidator(
   existingCurpValidationService: ExistingCurpValidationService,
-  table: string
+  table: string,
+  id_persona: number | undefined
 ): AsyncValidatorFn {
   return ({
     value: curp,
@@ -70,6 +71,7 @@ export function existingCurpAsyncValidator(
       .validate({
         curp,
         table,
+        id_persona,
       })
       .pipe(
         map(() => {
@@ -87,7 +89,8 @@ export function existingCurpAsyncValidator(
 export function existingPhonesAsyncValidator(
   validatorExistingPhoneService: ValidatorExistingPhoneService,
   table: tableType,
-  type: phoneType
+  type: phoneType,
+  id_persona: number | undefined
 ): AsyncValidatorFn {
   return ({
     value: phone,
@@ -96,6 +99,7 @@ export function existingPhonesAsyncValidator(
     const payload = {
       [type]: phone,
       table,
+      id_persona,
     };
     return validatorExistingPhoneService.validate(payload).pipe(
       map(() => {


### PR DESCRIPTION
- se reimplemento logica para la creacion de las validaciones asincronas, la version anterior tenia un problema que no permitia que los validadores asincronos tuvieran acceso a las varibales a nivel de clase, asi que se opto por generar triggers cuando el input obtiene el foco para re-asignar un validador asincrono con los datos actuales de los cientes existentes que fueron o no previamente cargados
- se hizo limpieza del ina inicializacion del formulario principal dado a que el validador asincrono ya no tenia reelevancia porque el punto anterior suple esa funcion.