### PR TITLE
fix: correccion trim() y fechas en template

### DIFF
--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -12,6 +12,8 @@
     <p *ngIf="modifiedBy">Modificado por: {{ modified_by_name }}</p>
     <p *ngIf="modifiedDate">
       Fecha de modificación: {{ modifiedDate | date: 'medium': 'UTC' }}
+    <p>Cerrado por: {{ closed_by_name }}</p>
+    <p>Fecha de cierre: {{ closedDate | date: 'medium': 'UTC'}}</p>
   </p-card>
 }
 <form [formGroup]="mainForm" (ngSubmit)="onSubmit()">

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -8,10 +8,10 @@
     <p>Folio de solicitud: {{ loanRequestId }}</p>
     <p>Carpeta de documentación: {{ customerFolderName }}</p>
     <p>Creado por: {{ nombre_agente }}</p>
-    <p>Fecha de creación: {{ createdDate | date: 'long' }}</p>
+    <p>Fecha de creación: {{ createdDate | date: 'medium': 'UTC'}}</p>
     <p *ngIf="modifiedBy">Modificado por: {{ modified_by_name }}</p>
     <p *ngIf="modifiedDate">
-      Fecha de modificación: {{ modifiedDate | date: 'long' }}
+      Fecha de modificación: {{ modifiedDate | date: 'medium': 'UTC' }}
   </p-card>
 }
 <form [formGroup]="mainForm" (ngSubmit)="onSubmit()">

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -546,7 +546,9 @@ export class LoanComponent implements OnDestroy, OnInit {
       request_number: this.loanRequestId,
       modified_by: this.currentUser?.ID,
       user_role: this.currentUser?.ROL,
-      observaciones: this.observationsHistory.trim(),
+      ...(this.observationsHistory
+        ? { observaciones: this.observationsHistory.trim() }
+        : {}),
     };
     return removeEmptyValues(requestData);
   }


### PR DESCRIPTION
Correccion del error en el campo de observaciones cuando esta vacio daba error al intentar invocar la funcion trim(), y como era nulo (vacio) arrojaba un error silencioso para el usuario, ya se corrigio para que solo cuando el campo tenga valor pueda hacer uso del trim().

tambien se hizo un pequeño cambio en el template de la pagina de solicitudes, la seccion que viene justo al principio en modo view. Como la fecha ya viene en la zona horaria correcta, no es necesario hacer la transformacion automatica por parte del date pipe, asi que le agregue UTC para que simplemente no hiciera transformacion de zona horaria a una fecha que ya viene con la zona horaria correcta.