### PR TITLE
fix: nueva logica en validador de cantidades

### DIFF
--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -992,11 +992,6 @@ export class LoanComponent implements OnDestroy, OnInit {
     ]);
     inputElement?.setValue(this.customLoanAmount);
     inputElement?.updateValueAndValidity();
-    console.log({
-      cantidad_restante,
-      customLoanRefinanceAmount: this.customLoanRefinanceAmount,
-      customLoanAmount: this.customLoanAmount,
-    });
   }
 
   updateEndorsmentFormFields(data: Guarantor) {


### PR DESCRIPTION
habia un error que aparecio con un caso de una solicitud la cual era un refinanciamiento, el validador del campo de cantidad a prestar colocaba el valor capturado como minimo, pero no deberia ser el caso.

- ahora el campo de cantidad a prestar tiene el valor de la variable a nivel de componente llamada minLoanAmount, actualmente es de 1000
- se agrego un valor por defecto a la funcion que cambia el validador de ese campo, asi tambien como en una de sus llamadas que no se estaban mandando los argumentos correctos
- agregado un else para cuando no se trate de un refinanciamiento, sino de una solicitud normal