### PR TITLE
chore: nuevo boton de eliminacion de refinanciamientos

### DIFF
--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -28,7 +28,7 @@
     orientation="vertical"
     style="max-width: 720px; margin: 0 auto">
     <!-- inicio de Cantidades y plazos -->
-    <p-stepperPanel header="Cantidades y plazos">
+    <p-stepperPanel header="Cantidades y plazos 💵">
       <ng-template
         pTemplate="content"
         let-index="index"
@@ -201,6 +201,14 @@
                     | currency: 'MXN' : 'symbol' : '1.2-2'
                 " />
             </p-inputGroup>
+            <div
+              class="w-full flex justify-content-center align-items-center pr-3 mt-3 column-gap-3">
+              <span>¿Eliminar refinanciamiento?</span>
+              <p-button
+                label="Eliminar"
+                icon="pi pi-undo"
+                (onClick)="refinanceResultsClear()" />
+            </div>
           }
         </div>
         <div class="flex justify-content-end pb-4 gap-2 pr-3">
@@ -215,7 +223,7 @@
     <!-- fin de Cantidades y plazos -->
 
     <!-- inicio de Datos del ciente -->
-    <p-stepperPanel header="Datos del cliente">
+    <p-stepperPanel header="Datos del cliente 🙋">
       <ng-template
         pTemplate="content"
         let-prevCallback="prevCallback"
@@ -612,7 +620,7 @@
     <!-- final de Datos del ciente -->
 
     <!-- inicio camposAval -->
-    <p-stepperPanel header="Datos de aval">
+    <p-stepperPanel header="Datos del aval 🙋">
       <ng-template
         pTemplate="content"
         let-prevCallback="prevCallback"
@@ -978,7 +986,7 @@
     <!-- fin de camposAval -->
 
     <!-- inicio Documentación -->
-    <p-stepperPanel header="Documentación">
+    <p-stepperPanel header="Documentación 📂">
       <ng-template
         pTemplate="content"
         let-prevCallback="prevCallback"

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -960,7 +960,6 @@ export class LoanComponent implements OnDestroy, OnInit {
     const cantidad_prestada = this.mainForm.get('cantidad_prestada')?.value;
     this.refinanceResults.set(refinanceData);
     this.stepper()?.nextCallback(null, -1);
-    console.log({ refinanceData });
     if (refinanceData.cantidad_restante) {
       this.updateAmountValidator(
         cantidad_prestada,
@@ -1022,5 +1021,11 @@ export class LoanComponent implements OnDestroy, OnInit {
       cp_aval: data.cp,
       referencias_dom_aval: data.referencias_dom,
     });
+  }
+
+  refinanceResultsClear() {
+    this.refinanceResults.set(null);
+    this.stepper()?.nextCallback(null, -1);
+    this.updateAmountValidator(this.minLoanAmount);
   }
 }


### PR DESCRIPTION
Este cambio habilita la posibilidad de remover los datos de refinanciamento de una solicitud.

- Nuevo boton cuya funcion es eliminar el refinanciamiento previamente seleccionado, asi procurando que se pueda cambiar entre una solicitud normal y una basada en un refinanciamiento.

Imangen de ejemplo:

<img width="784" height="746" alt="image" src="https://github.com/user-attachments/assets/bc8c44ce-e238-43b4-bb53-5a0bdc351992" />
