### PR TITLE
fix: agregando la logica faltante

### DIFF
--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -1027,5 +1027,7 @@ export class LoanComponent implements OnDestroy, OnInit {
     this.refinanceResults.set(null);
     this.stepper()?.nextCallback(null, -1);
     this.updateAmountValidator(this.minLoanAmount);
+    this.cantidadIngresada = this.minLoanAmount;
+    this.calculaPrestamo()
   }
 }


### PR DESCRIPTION
- Cuando se eliminaba un refinanciamiento de una solicitud no se actualizaban los campos informativos del prestamo, dejando informacion vieja (stale) la cual viajaba en el payload al ser enviada dicha solicitud, asi que se agregaron las lineas faltantes para que fuera satisfactorio el cambio sin ninguna ambiguedad