### PR TITLE
chore: aplicando UTC

### DIFF
--- a/src/app/cobro-agenda/cobro-agenda.component.html
+++ b/src/app/cobro-agenda/cobro-agenda.component.html
@@ -307,12 +307,12 @@
       </td>
       <td>
         <span class="text-sm">{{
-          (cobro.fechaUltimoPago | date: 'dd/MM/yyyy') || 'N/A'
+          (cobro.fechaUltimoPago | date: 'dd/MM/yyyy' : 'UTC') || 'N/A'
         }}</span>
       </td>
       <td>
         <span class="text-sm">{{
-          cobro.fechaVencimiento | date: 'dd/MM/yyyy'
+          cobro.fechaVencimiento | date: 'dd/MM/yyyy' : 'UTC'
         }}</span>
       </td>
     </tr>


### PR DESCRIPTION
 ## PROBLEMA
Las fechas son guardadas siempre sin hacer una transformacion de GMT a UTC, esto causa una discrepacia de horas cuando se consume la informacion almacenada en la DB, la cual es siempre es y deberia de ser UTC, al consumir la fecha almacenada en la DB el cliente, en este caso la app web hace la transformacion inverda de UTC a GMT de manera automatica standard, pero como inicialmente no hubo transformacion de GMT->UTC la conversion de UTC->GMT no tiene caso, esto estaba causando la discrepancia de horas causando que el dia se muestre como dia anterior en zonas inferiores a UTC (con el simbolo de -, ej: GMT-6)

## SOLUCION
Este fix corrige eso para que la fecha se muestre sin hacer la transformacion a GMT sino que le dice que la mantenga como UTC con fines visuales para los usuarios.