### PR TITLE
Desktop url http

### DIFF
--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -27,7 +27,7 @@
         <span class="font-bold">{{ nombreUsuario | titlecase }} 👋</span>
       </div>
     </ng-template>
-    <p-panelMenu [model]="items" styleClass="w-full" pRipple />
+    <p-panelMenu [model]="menuItems()" styleClass="w-full" pRipple />
     <ng-template pTemplate="footer">
       <div class="flex align-items-center flex-column gap-2">
         <p-button

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -66,10 +66,6 @@ export class DashboardComponent {
     },
   ]);
 
-  toolbarItems: MenuItem[] = [
-    { icon: 'pi pi-bars', command: () => this.toggleSidebar() },
-  ];
-
   toggleSidebar() {
     this.isSidebarVisible = !this.isSidebarVisible;
   }

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,7 +1,8 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, computed } from '@angular/core';
 import { MenuItem } from 'primeng/api';
 import { AuthService } from 'src/app/login/services/AuthService';
 import { version } from '../../../package.json';
+import { DesktopAppService } from './services/desktop-app.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -11,11 +12,13 @@ import { version } from '../../../package.json';
 })
 export class DashboardComponent {
   private authService = inject(AuthService);
+  private desktopAppService = inject(DesktopAppService);
+
   isSidebarVisible = false;
   nombreUsuario = localStorage.getItem('nombreusuario') || 'quien eres?';
   appVersion = version;
 
-  items: MenuItem[] = [
+  menuItems = computed<MenuItem[]>(() => [
     {
       label: 'Altas',
       expanded: true,
@@ -54,16 +57,16 @@ export class DashboardComponent {
     {
       label: 'Desktop APP',
       icon: 'pi pi-fw pi-desktop',
-      url: 'https://www.mediafire.com/file/ohqloylfql6hti7/InstaladorYOOX-Release-2026-15-03.msi/file', // de momento esto estara hardcodeado hasta que exista un endpoint para obtener la ultima version
+      url: this.desktopAppService.desktopAppUrl(),
     },
     {
       label: 'Documentación',
       icon: 'pi pi-fw pi-book',
       url: 'https://yoox-docs.vercel.app/',
     },
-  ];
+  ]);
 
-  menuItems: MenuItem[] = [
+  toolbarItems: MenuItem[] = [
     { icon: 'pi pi-bars', command: () => this.toggleSidebar() },
   ];
 

--- a/src/app/dashboard/services/desktop-app.service.ts
+++ b/src/app/dashboard/services/desktop-app.service.ts
@@ -1,0 +1,22 @@
+import { Injectable, inject, computed } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { catchError, of } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+const DEFAULT_DESKTOP_APP_URL =
+  'https://www.mediafire.com/file/ohqloylfql6hti7/InstaladorYOOX-Release-2026-15-03.msi';
+
+@Injectable({ providedIn: 'root' })
+export class DesktopAppService {
+  private http = inject(HttpClient);
+  private baseUrl = environment.API_URL;
+  private desktopAppResponse = toSignal(
+    this.http
+      .get<{ url: string }>(`${this.baseUrl}desktop-app-url`)
+      .pipe(catchError(() => of({ url: DEFAULT_DESKTOP_APP_URL }))),
+    { initialValue: { url: DEFAULT_DESKTOP_APP_URL } }
+  );
+
+  desktopAppUrl = computed(() => this.desktopAppResponse().url);
+}


### PR DESCRIPTION
Nuevo servicio para obtener la version mas reciente de la app desktop desde el backend para asi evitar hardcodear la url cada vez que exista una nueva version.

Si por algo el servicio fallara en obtener la url del endpoint se deja un fallback de una de las versiones para que por lo menos puedan descargarla y actualizarla desde la misma app desktop sin depender de la web.

Se realizo el cambio usando signals porque involucra un cambio en el template, esto para seguir las buenas practicas propuestas por el equipo de Angular.