### PR TITLE
Persistecia filtrado en listado de solicitudes

### DIFF
--- a/src/app/request-list/request-list.component.css
+++ b/src/app/request-list/request-list.component.css
@@ -25,3 +25,17 @@
 .dataview {
   margin-bottom: 0;
 }
+
+.viewport {
+  height: 100%;
+  overflow: auto;
+}
+
+.scroll-container {
+  height: 100%;
+}
+
+#card {
+  height: 100%;
+  background: #1f2937;
+}

--- a/src/app/request-list/request-list.component.css
+++ b/src/app/request-list/request-list.component.css
@@ -27,8 +27,10 @@
 }
 
 .viewport {
-  height: 100%;
+  height: 84dvh;
   overflow: auto;
+  margin-top: 0.5rem;
+  border-radius: 0.5rem;
 }
 
 .scroll-container {

--- a/src/app/request-list/request-list.component.html
+++ b/src/app/request-list/request-list.component.html
@@ -35,74 +35,78 @@
     @if (requests().length === 0) {
       <p class="center">No hay solicitudes</p>
     } @else {
-      <p-dataView #dv class="m-2 w-full dataview" [value]="requests()">
-        <ng-template pTemplate="list" let-requests>
+      <div class="m-2 w-full dataview">
+        <cdk-virtual-scroll-viewport
+          itemSize="80"
+          class="viewport"
+          [style.height.dvh]="86"
+          className="scroll-container">
           <div class="grid grid-nogutter">
-            @for (
-              item of requests;
-              track item.request_number;
-              let first = $first
-            ) {
-              <div class="col-12">
+            <div
+              *cdkVirtualFor="
+                let item of requests();
+                trackBy: trackByRequestNumber;
+                let first = first
+              "
+              class="col-12">
+              <div
+                id="card"
+                class="flex flex-column sm:flex-row sm:align-items-center p-4 gap-3"
+                [ngClass]="{ 'border-top-1 surface-border': !first }">
+                <div class="md:w-10rem relative">
+                  <p-tag
+                    [severity]="getSeverity(item)"
+                    [style.left.px]="4"
+                    [value]="item.loan_request_status"
+                    [style.top.px]="4" />
+                </div>
                 <div
-                  class="flex flex-column sm:flex-row sm:align-items-center p-4 gap-3"
-                  [ngClass]="{ 'border-top-1 surface-border': !first }">
-                  <div class="md:w-10rem relative">
-                    <p-tag
-                      [severity]="getSeverity(item)"
-                      [style.left.px]="4"
-                      [value]="item.loan_request_status"
-                      [style.top.px]="4" />
-                  </div>
+                  class="flex flex-column md:flex-row justify-content-between md:align-items-center flex-1 gap-4">
                   <div
-                    class="flex flex-column md:flex-row justify-content-between md:align-items-center flex-1 gap-4">
-                    <div
-                      class="flex flex-row md:flex-column justify-content-between align-items-start gap-2">
-                      <div>
-                        <span class="font-medium text-secondary text-sm">
-                          <span class="pi pi-user"></span>
-                          {{ item.nombre_cliente | uppercase }}
-                          {{ item.apellido_paterno_cliente | uppercase }}
-                          {{ item.apellido_materno_cliente | uppercase }}
-                        </span>
-                        <div class="font-medium text-secondary text-sm mt-2">
-                          <span class="pi pi-hashtag"></span>
-                          {{ item.request_number | uppercase }}
-                        </div>
-                        <div class="text-lg font-medium text-900 mt-2">
-                          <span class="pi pi-file-pdf"></span>
-                          {{ item.request_number }}-{{
-                            item.apellido_paterno_cliente | uppercase
-                          }}
-                        </div>
+                    class="flex flex-row md:flex-column justify-content-between align-items-start gap-2">
+                    <div>
+                      <span class="font-medium text-secondary text-sm">
+                        <span class="pi pi-user"></span>
+                        {{ item.nombre_cliente | uppercase }}
+                        {{ item.apellido_paterno_cliente | uppercase }}
+                        {{ item.apellido_materno_cliente | uppercase }}
+                      </span>
+                      <div class="font-medium text-secondary text-sm mt-2">
+                        <span class="pi pi-hashtag"></span>
+                        {{ item.request_number | uppercase }}
                       </div>
-                      <div>
-                        <span
-                          ><span class="pi pi-calendar-plus"></span>
-                          {{ item.created_date | date }}</span
-                        >
+                      <div class="text-lg font-medium text-900 mt-2">
+                        <span class="pi pi-file-pdf"></span>
+                        {{ item.request_number }}-{{
+                          item.apellido_paterno_cliente | uppercase
+                        }}
                       </div>
                     </div>
-                    <div
-                      class="flex flex-column md:align-items-end gap-2 md:gap-5">
-                      <span class="text-xl font-semibold text-900">
-                        ${{ item.cantidad_prestada | number }}
-                      </span>
-                      <div
-                        class="flex justify-content-center md:flex-row gap-2">
-                        <p-button
-                          icon="pi pi-file-edit"
-                          label="Revisar"
-                          (click)="openRecord(item)" />
-                      </div>
+                    <div>
+                      <span
+                        ><span class="pi pi-calendar-plus"></span>
+                        {{ item.created_date | date }}</span
+                      >
+                    </div>
+                  </div>
+                  <div
+                    class="flex flex-column md:align-items-end gap-2 md:gap-5">
+                    <span class="text-xl font-semibold text-900">
+                      ${{ item.cantidad_prestada | number }}
+                    </span>
+                    <div class="flex justify-content-center md:flex-row gap-2">
+                      <p-button
+                        icon="pi pi-file-edit"
+                        label="Revisar"
+                        (click)="openRecord(item)" />
                     </div>
                   </div>
                 </div>
               </div>
-            }
+            </div>
           </div>
-        </ng-template>
-      </p-dataView>
+        </cdk-virtual-scroll-viewport>
+      </div>
     }
   </section>
   <p-sidebar [(visible)]="showFilterMenu" position="right">

--- a/src/app/request-list/request-list.component.html
+++ b/src/app/request-list/request-list.component.html
@@ -39,7 +39,6 @@
         <cdk-virtual-scroll-viewport
           itemSize="80"
           class="viewport"
-          [style.height.dvh]="86"
           className="scroll-container">
           <div class="grid grid-nogutter">
             <div

--- a/src/app/request-list/request-list.component.ts
+++ b/src/app/request-list/request-list.component.ts
@@ -264,12 +264,7 @@ export class RequestListComponent implements OnInit {
     this.selectedGrupo = null;
     this.selectedGerencia = null;
     this.selectedStatus = null;
-    this.state.filters = {
-      selectedAgente: this.selectedAgente,
-      selectedGrupo: this.selectedGrupo,
-      selectedGerencia: this.selectedGerencia,
-      selectedStatus: this.selectedStatus,
-    };
+    this.setStateFilters();
   }
 
   restoreOrderDefaults() {
@@ -291,12 +286,7 @@ export class RequestListComponent implements OnInit {
         managementIdFilter: this.selectedGerencia.ID,
       }),
     };
-    this.state.filters = {
-      selectedAgente: this.selectedAgente,
-      selectedGrupo: this.selectedGrupo,
-      selectedGerencia: this.selectedGerencia,
-      selectedStatus: this.selectedStatus,
-    };
+    this.setStateFilters();
     this.getRequestListItems(options);
     this.restoreOrderDefaults();
   }

--- a/src/app/request-list/request-list.component.ts
+++ b/src/app/request-list/request-list.component.ts
@@ -32,6 +32,7 @@ import {
   RequestListOptions,
   Requests,
   User,
+  State,
 } from './types/requests';
 import { RequestListService } from './services/request-list.service';
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
@@ -57,8 +58,8 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
   ],
   templateUrl: './request-list.component.html',
   styleUrls: ['./request-list.component.css'],
-  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [MessageService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RequestListComponent implements OnInit {
   readonly #destroyRef$ = inject(DestroyRef);
@@ -91,18 +92,13 @@ export class RequestListComponent implements OnInit {
   totalRecords: number = 0;
   first: number = 0;
   rows: number = 5;
+  state!: State;
 
   ngOnInit(): void {
-    const { data } = this.#requestListService.recover();
     this.showLoadingModal = true;
-    if (data.totalRecords > 0) {
-      this.requests.set(data.loanRequests);
-      this.requestUserList.set(data.usersList);
-      this.groups.set(data.groups);
-      this.management.set(data.management);
-      this.filterRequest = false;
-      this.totalRecords = data.totalRecords;
-      this.unfilteredRequests = [...data.unfilteredRequests];
+    this.state = this.#requestListService.recover();
+    if (this.state.data.totalRecords > 0) {
+      this.setRecoveredState();
       this.showLoadingModal = false;
     } else {
       this.getRequestListItems({
@@ -130,6 +126,23 @@ export class RequestListComponent implements OnInit {
     { label: 'Actualizar', value: LoanStatusEnum.actualizar },
   ];
 
+  private setRecoveredState() {
+    const { data, filters } = this.state;
+    this.requests.set(data.loanRequests);
+    this.requestUserList.set(data.usersList);
+    this.groups.set(data.groups);
+    this.management.set(data.management);
+    this.filterRequest = false;
+    this.totalRecords = data.totalRecords;
+    this.unfilteredRequests = [...data.unfilteredRequests];
+    this.selectedGerencia = filters.selectedGerencia;
+    this.selectedGrupo = filters.selectedGrupo;
+    this.selectedAgente = filters.selectedAgente;
+    this.selectedStatus = filters.selectedStatus;
+    this.selectedOrdenFecha = filters.selectedOrdenFecha;
+    this.selectedOrdenCantidad = filters.selectedOrdenCantidad;
+  }
+
   getSeverity(request: Requests) {
     switch (request.loan_request_status) {
       case 'APROBADO':
@@ -143,7 +156,7 @@ export class RequestListComponent implements OnInit {
 
   orderbyDate(direction: 'asc' | 'desc') {
     this.requests.update((requests) =>
-      requests.sort((a, b) => {
+      [...requests].sort((a, b) => {
         if (direction === 'asc') {
           return (
             new Date(a.created_date).getTime() -
@@ -156,17 +169,19 @@ export class RequestListComponent implements OnInit {
         );
       })
     );
+    this.state.data.loanRequests = this.requests();
   }
 
   orderbyAmount(direction: 'asc' | 'desc') {
     this.requests.update((requests) =>
-      requests.sort((a, b) => {
+      [...requests].sort((a, b) => {
         if (direction === 'asc') {
           return a.cantidad_prestada - b.cantidad_prestada;
         }
         return b.cantidad_prestada - a.cantidad_prestada;
       })
     );
+    this.state.data.loanRequests = this.requests();
   }
 
   trackByRequestNumber(_: number, item: Requests): string {
@@ -179,42 +194,52 @@ export class RequestListComponent implements OnInit {
       .pipe(takeUntilDestroyed(this.#destroyRef$))
       .subscribe({
         next: (data: RequestList) => {
-          this.showLoadingModal = false;
-          this.requests.set(data.loanRequests);
-          this.requestUserList.set(data.usersList);
-          this.groups.set(data.groups);
-          this.management.set(data.management);
-          this.filterRequest = false;
-          this.totalRecords = data.loanRequests[0].CNT;
-          this.unfilteredRequests = [...data.loanRequests];
-          this.#requestListService.save(
-            {},
-            {
-              ...data,
-              totalRecords: this.totalRecords,
-              unfilteredRequests: this.unfilteredRequests,
-            }
-          );
+          this.setSucessfullData(data);
         },
         error: (errorRes: HttpErrorResponse) => {
-          this.requests.set([]);
-          this.unfilteredRequests = [];
-          this.showLoadingModal = false;
-          this.filterRequest = false;
-          this.#requestListService.clean();
-          this.#messageService.add({
-            severity: 'error',
-            summary: errorRes.error?.message || errorRes.name,
-            detail: errorRes.error?.error || errorRes.status,
-            life: 3000,
-          });
+          this.setFailedData(errorRes);
         },
       });
+  }
+
+  private setFailedData(errorRes: HttpErrorResponse) {
+    this.requests.set([]);
+    this.unfilteredRequests = [];
+    this.showLoadingModal = false;
+    this.filterRequest = false;
+    this.#requestListService.clean();
+    this.#messageService.add({
+      severity: 'error',
+      summary: errorRes.error?.message || errorRes.name,
+      detail: errorRes.error?.error || errorRes.status,
+      life: 3000,
+    });
+  }
+
+  private setSucessfullData(data: RequestList) {
+    this.showLoadingModal = false;
+    this.requests.set(data.loanRequests);
+    this.requestUserList.set(data.usersList);
+    this.groups.set(data.groups);
+    this.management.set(data.management);
+    this.filterRequest = false;
+    this.totalRecords = data.loanRequests[0].CNT;
+    this.unfilteredRequests = [...data.loanRequests];
+    this.state = {
+      filters: {},
+      data: {
+        ...data,
+        totalRecords: this.totalRecords,
+        unfilteredRequests: this.unfilteredRequests,
+      },
+    };
   }
 
   // EVENTS
   openRecord(solicitud: Requests) {
     const loan_request = solicitud.request_number;
+    this.setStateFilters();
+    this.#requestListService.save(this.state);
     this.router.navigate([`/dashboard/loan-request/view/${loan_request}`]);
   }
 
@@ -239,6 +264,12 @@ export class RequestListComponent implements OnInit {
     this.selectedGrupo = null;
     this.selectedGerencia = null;
     this.selectedStatus = null;
+    this.state.filters = {
+      selectedAgente: this.selectedAgente,
+      selectedGrupo: this.selectedGrupo,
+      selectedGerencia: this.selectedGerencia,
+      selectedStatus: this.selectedStatus,
+    };
   }
 
   restoreOrderDefaults() {
@@ -258,6 +289,12 @@ export class RequestListComponent implements OnInit {
       ...(this.selectedGerencia && {
         managementIdFilter: this.selectedGerencia.ID,
       }),
+    };
+    this.state.filters = {
+      selectedAgente: this.selectedAgente,
+      selectedGrupo: this.selectedGrupo,
+      selectedGerencia: this.selectedGerencia,
+      selectedStatus: this.selectedStatus,
     };
     this.getRequestListItems(options);
     this.restoreOrderDefaults();
@@ -286,6 +323,7 @@ export class RequestListComponent implements OnInit {
     }
   }
 
+  // Filtros
   onAgenteChange(event: any) {
     this.selectedAgente = this.selectedAgente = event.value;
     this.selectedGrupo = null;
@@ -308,6 +346,7 @@ export class RequestListComponent implements OnInit {
     this.selectedStatus = event.value;
   }
 
+  // Ordenamiento
   onOrdenFechaChange(event: any) {
     this.selectedOrdenCantidad = null;
     switch (event.value) {
@@ -330,5 +369,16 @@ export class RequestListComponent implements OnInit {
         this.orderbyAmount('desc');
         break;
     }
+  }
+
+  setStateFilters() {
+    this.state.filters = {
+      selectedAgente: this.selectedAgente,
+      selectedGrupo: this.selectedGrupo,
+      selectedGerencia: this.selectedGerencia,
+      selectedStatus: this.selectedStatus,
+      selectedOrdenFecha: this.selectedOrdenFecha,
+      selectedOrdenCantidad: this.selectedOrdenCantidad,
+    };
   }
 }

--- a/src/app/request-list/request-list.component.ts
+++ b/src/app/request-list/request-list.component.ts
@@ -276,6 +276,7 @@ export class RequestListComponent implements OnInit {
     this.fechaDropdown()?.clear();
     this.cantidadDropdown()?.clear();
     this.requests.update(() => [...this.unfilteredRequests]);
+    this.state.data.loanRequests = this.requests();
   }
 
   applySearchRules() {

--- a/src/app/request-list/request-list.component.ts
+++ b/src/app/request-list/request-list.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import {
+  ChangeDetectionStrategy,
   Component,
   DestroyRef,
   inject,
@@ -12,7 +13,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 import { ButtonModule } from 'primeng/button';
 import { CardModule } from 'primeng/card';
-import { DataViewModule } from 'primeng/dataview';
+
 import { DialogModule } from 'primeng/dialog';
 import { InputTextModule } from 'primeng/inputtext';
 import { MessageService } from 'primeng/api';
@@ -35,6 +36,7 @@ import {
 import { RequestListService } from './services/request-list.service';
 import { Dropdown, DropdownModule } from 'primeng/dropdown';
 import { SidebarModule } from 'primeng/sidebar';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @Component({
   selector: 'app-request-list',
@@ -42,12 +44,12 @@ import { SidebarModule } from 'primeng/sidebar';
     ButtonModule,
     CardModule,
     CommonModule,
-    DataViewModule,
     DialogModule,
     InputTextModule,
     MenubarModule,
     PaginatorModule,
     ProgressSpinnerModule,
+    ScrollingModule,
     TagModule,
     ToastModule,
     DropdownModule,
@@ -55,6 +57,7 @@ import { SidebarModule } from 'primeng/sidebar';
   ],
   templateUrl: './request-list.component.html',
   styleUrls: ['./request-list.component.css'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   providers: [MessageService],
 })
 export class RequestListComponent implements OnInit {
@@ -90,11 +93,23 @@ export class RequestListComponent implements OnInit {
   rows: number = 5;
 
   ngOnInit(): void {
+    const { data } = this.#requestListService.recover();
     this.showLoadingModal = true;
-    this.getRequestListItems({
-      offSetRows: this.first,
-      fetchRowsNumber: this.rows,
-    });
+    if (data.totalRecords > 0) {
+      this.requests.set(data.loanRequests);
+      this.requestUserList.set(data.usersList);
+      this.groups.set(data.groups);
+      this.management.set(data.management);
+      this.filterRequest = false;
+      this.totalRecords = data.totalRecords;
+      this.unfilteredRequests = [...data.unfilteredRequests];
+      this.showLoadingModal = false;
+    } else {
+      this.getRequestListItems({
+        offSetRows: this.first,
+        fetchRowsNumber: this.rows,
+      });
+    }
   }
 
   // COMPONENT FUNCTIONS
@@ -127,8 +142,8 @@ export class RequestListComponent implements OnInit {
   }
 
   orderbyDate(direction: 'asc' | 'desc') {
-    this.requests.update(() =>
-      this.requests().sort((a, b) => {
+    this.requests.update((requests) =>
+      requests.sort((a, b) => {
         if (direction === 'asc') {
           return (
             new Date(a.created_date).getTime() -
@@ -144,14 +159,18 @@ export class RequestListComponent implements OnInit {
   }
 
   orderbyAmount(direction: 'asc' | 'desc') {
-    this.requests.update(() =>
-      this.requests().sort((a, b) => {
+    this.requests.update((requests) =>
+      requests.sort((a, b) => {
         if (direction === 'asc') {
           return a.cantidad_prestada - b.cantidad_prestada;
         }
         return b.cantidad_prestada - a.cantidad_prestada;
       })
     );
+  }
+
+  trackByRequestNumber(_: number, item: Requests): string {
+    return item.request_number;
   }
 
   getRequestListItems(options: RequestListOptions) {
@@ -161,23 +180,32 @@ export class RequestListComponent implements OnInit {
       .subscribe({
         next: (data: RequestList) => {
           this.showLoadingModal = false;
-          this.requests.update(() => data.loanRequests);
-          this.requestUserList.update(() => data.usersList);
-          this.groups.update(() => data.groups);
-          this.management.update(() => data.management);
+          this.requests.set(data.loanRequests);
+          this.requestUserList.set(data.usersList);
+          this.groups.set(data.groups);
+          this.management.set(data.management);
           this.filterRequest = false;
           this.totalRecords = data.loanRequests[0].CNT;
           this.unfilteredRequests = [...data.loanRequests];
+          this.#requestListService.save(
+            {},
+            {
+              ...data,
+              totalRecords: this.totalRecords,
+              unfilteredRequests: this.unfilteredRequests,
+            }
+          );
         },
         error: (errorRes: HttpErrorResponse) => {
-          this.requests.update(() => []);
+          this.requests.set([]);
           this.unfilteredRequests = [];
           this.showLoadingModal = false;
           this.filterRequest = false;
+          this.#requestListService.clean();
           this.#messageService.add({
             severity: 'error',
             summary: errorRes.error?.message || errorRes.name,
-            detail: errorRes.error?.error || errorRes.statusText,
+            detail: errorRes.error?.error || errorRes.status,
             life: 3000,
           });
         },

--- a/src/app/request-list/services/request-list.service.ts
+++ b/src/app/request-list/services/request-list.service.ts
@@ -43,8 +43,8 @@ export class RequestListService {
     );
   }
 
-  save(filters: any, data: RequestListState) {
-    this.state = { filters, data };
+  save(payload: { filters: any; data: RequestListState }) {
+    this.state = { filters: payload.filters, data: payload.data };
   }
 
   recover() {

--- a/src/app/request-list/services/request-list.service.ts
+++ b/src/app/request-list/services/request-list.service.ts
@@ -1,13 +1,29 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from 'src/environments/environment';
-import { RequestList, RequestListOptions } from '../types/requests';
+import {
+  RequestList,
+  RequestListOptions,
+  RequestListState,
+  State,
+} from '../types/requests';
 import { TokenUserData } from 'src/app/shared/interfaces/userData.interface';
 
 @Injectable({ providedIn: 'root' })
 export class RequestListService {
   readonly #http = inject(HttpClient);
   readonly #baseUrl = environment.API_URL;
+  private state: State = {
+    filters: {} as any,
+    data: {
+      loanRequests: [],
+      usersList: [],
+      groups: [],
+      management: [],
+      unfilteredRequests: [],
+      totalRecords: 0,
+    },
+  };
 
   getRequestsList(options: RequestListOptions) {
     const user: TokenUserData = JSON.parse(localStorage.getItem('user')!);
@@ -25,5 +41,27 @@ export class RequestListService {
         },
       }
     );
+  }
+
+  save(filters: any, data: RequestListState) {
+    this.state = { filters, data };
+  }
+
+  recover() {
+    return this.state;
+  }
+
+  clean() {
+    this.state = {
+      filters: {},
+      data: {
+        loanRequests: [],
+        usersList: [],
+        groups: [],
+        management: [],
+        unfilteredRequests: [],
+        totalRecords: 0,
+      },
+    };
   }
 }

--- a/src/app/request-list/types/requests.ts
+++ b/src/app/request-list/types/requests.ts
@@ -63,3 +63,13 @@ export interface Groups {
   label?: string;
   ID?: number;
 }
+
+export interface RequestListState extends RequestList {
+  unfilteredRequests: Requests[];
+  totalRecords: number;
+}
+
+export interface State {
+  filters: any;
+  data: RequestListState;
+}


### PR DESCRIPTION
## Problema
Se hicieron 2 cambios importantes al componente de listado de solicitudes:

1. El primero es la persistencia de los datos cuando se usa el filtrado/ordenamiento.
2. El segundo es una mejora importante en performance en el template, el problema era que cuando se accedia con una cuenta de administrador o similar, la bd podria regresar miles de registros, los cuales como estaba originalemente hacia un 'for' en el template para ciclar y procesar como se deben renderizar, y por un par de segundos la pantalla estaba vacia siendo que los elementos ya habian sigo obtenidos por la db

## Implementaciones

1. Se creo un servicio para mantener en memoria el estado del ordenamiento y filtrado, asi para cuando el usuario hace uso de ellos para revisar a detalle una solicitud de prestamo y posteriormente regresar a la pantalla anterior vera todos los elementos previamente filtrados y ordenados tal cual antes de acceder a alguna solicitud.
2. Se cambio el for por un for especializado para estos casos el cual hace uso de un listado virtual, el cual procesa solo los primeros elementos de un arreglo de miles, asi estos elementos se renderizan instantaneamente y conforme se hace scroll va dibujando en pantalla los siguientes, esto incrementa bastante para bien la experiencia de usuario porque logra que todo se sienta mucho mas rapido que antes, el unico drawback es que para que esto funcione se genera un elemento en el DOM con tamaño especifico y por ende le agrega una barra extra de desplazamiento horizontal, no es en si un problema, pero igualmente intente dejarlo lo mejor posible para que esa barra no aparezca en la medida de lo posible.

### Video de persistencia de filtrado/ordenado
[Screencast_20260318_170345.webm](https://github.com/user-attachments/assets/2b464b8c-5275-40d9-9ae7-2425947dca06)
