### PR TITLE
chore: mayusculas en formulario

### DIFF
--- a/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.html
+++ b/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.html
@@ -1,38 +1,44 @@
 <div
-  class="grid py-3 pr-3 mr-1 row-gap-3 max-w-89vw md:max-w-55vw"
+  class="grid py-3 pr-3 mr-1 row-gap-1 max-w-89vw md:max-w-55vw"
   [formGroup]="customerSearchForm">
-  <p-inputNumber
-    placeholder="Código"
-    inputId="ID"
-    useGrouping="false"
-    min="0"
-    class="col-12 sm:col-6 p-0"
-    [style]="{ width: '100%' }"
-    formControlName="id" />
-  <input
-    pInputText
-    appUppercase
-    placeholder="CURP"
-    id="CURP"
-    class="col-12 sm:col-6"
-    formControlName="curp" />
-  <small id="curp_cliente-help" class="mb-2 text-red-500">
-    @if (customerSearchForm.get('curp')?.errors?.['invalidCurp']) {
-      <ng-container> Formato de CURP invalido</ng-container>
-    }
-  </small>
+  <div class="col-12 sm:col-6">
+    <p-inputNumber
+      placeholder="Código"
+      inputId="ID"
+      useGrouping="false"
+      class="w-full"
+      min="0"
+      [style]="{ width: '100%' }"
+      formControlName="id" />
+  </div>
+  <div class="col-12 sm:col-6">
+    <input
+      pInputText
+      appUppercase
+      placeholder="CURP"
+      id="CURP"
+      class="w-full"
+      formControlName="curp" />
+    <small id="curp_cliente-help" class="mb-2 text-red-500">
+      @if (customerSearchForm.get('curp')?.errors?.['invalidCurp']) {
+        <ng-container> Formato de CURP invalido</ng-container>
+      }
+    </small>
+  </div>
+  <div class="col-12 sm:col-6">
+    <input
+      pInputText
+      appUppercase
+      placeholder="Nombre"
+      class="w-full"
+      id="Nombre"
+      formControlName="nombre" />
+  </div>
 
-  <input
-    pInputText
-    appUppercase
-    placeholder="Nombre"
-    id="Nombre"
-    class="col-12"
-    formControlName="nombre" />
   <div style="margin: 0 auto; margin-top: 10px">
     <button
       pButton
-      label="Buscar"
+      [label]="'Buscar ' + searchOnTable()"
       icon="pi pi-search"
       type="submit"
       [loading]="loading()"

--- a/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.html
+++ b/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.html
@@ -11,12 +11,20 @@
     formControlName="id" />
   <input
     pInputText
+    appUppercase
     placeholder="CURP"
     id="CURP"
     class="col-12 sm:col-6"
     formControlName="curp" />
+  <small id="curp_cliente-help" class="mb-2 text-red-500">
+    @if (customerSearchForm.get('curp')?.errors?.['invalidCurp']) {
+      <ng-container> Formato de CURP invalido</ng-container>
+    }
+  </small>
+
   <input
     pInputText
+    appUppercase
     placeholder="Nombre"
     id="Nombre"
     class="col-12"

--- a/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.ts
+++ b/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.ts
@@ -30,6 +30,7 @@ import {
 } from '../../types/searchCustomers.interface';
 import { estadosDeLaRepublica, tiposCalle } from '../../utils/consts';
 import { ResultadosBusquedaCliente } from '../../types/loan-request.interface';
+import { UppercaseDirective } from 'src/app/shared/directives/uppercase.directive';
 
 @Component({
   selector: 'app-people-search',
@@ -43,6 +44,7 @@ import { ResultadosBusquedaCliente } from '../../types/loan-request.interface';
     TableModule,
     ToastModule,
     TooltipModule,
+    UppercaseDirective,
   ],
   providers: [MessageService],
   templateUrl: './busqueda-clientes.component.html',

--- a/src/app/loan-request/loan-request.module.ts
+++ b/src/app/loan-request/loan-request.module.ts
@@ -29,6 +29,7 @@ import { ListS3FilesComponent } from './components/list-s3-files/list-s3-files.c
 import { LoanComponent } from './pages/loan/new-loan.component';
 import { LoanRequestRoutingModule } from './loan-request-routing.module';
 import { RefinanceSearchComponent } from './components/refinance-search/refinance-search.component';
+import { UppercaseDirective } from '../shared/directives/uppercase.directive';
 
 @NgModule({
   declarations: [LoanComponent],
@@ -60,7 +61,8 @@ import { RefinanceSearchComponent } from './components/refinance-search/refinanc
     ListS3FilesComponent,
     CardModule,
     RefinanceSearchComponent,
+    UppercaseDirective,
   ],
   providers: [ConfirmationService, MessageService],
 })
-export class LoanRequestModule {}
+export class LoanRequestModule { }

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -274,7 +274,7 @@
             <input
               formControlName="nombre_cliente"
               pInputText
-              oninput="this.value = this.value.toUpperCase()"
+              appUppercase
               id="nombre_cliente"
               maxlength="50"
               aria-describedby="nombre_cliente-help" />
@@ -290,7 +290,7 @@
             <input
               formControlName="apellido_paterno_cliente"
               pInputText
-              oninput="this.value = this.value.toUpperCase()"
+              appUppercase
               id="apellido_paterno_cliente"
               maxlength="50"
               aria-describedby="apellido_paterno_cliente-help" />
@@ -306,7 +306,7 @@
             <input
               formControlName="apellido_materno_cliente"
               pInputText
-              oninput="this.value = this.value.toUpperCase()"
+              appUppercase
               id="apellido_materno_cliente"
               maxlength="50"
               aria-describedby="apellido_materno_cliente-help" />
@@ -385,6 +385,7 @@
             <label for="correo_electronico_cliente">Correo electronico</label>
             <input
               pInputText
+              appUppercase
               formControlName="correo_electronico_cliente"
               id="correo_electronico_cliente"
               maxlength="100"
@@ -400,6 +401,7 @@
             <label for="ocupacion_cliente">Ocupación</label>
             <input
               pInputText
+              appUppercase
               formControlName="ocupacion_cliente"
               id="ocupacion_cliente"
               maxlength="50"
@@ -484,6 +486,7 @@
             <label for="nombre_calle_cliente">Nombre de la calle</label>
             <input
               pInputText
+              appUppercase
               formControlName="nombre_calle_cliente"
               id="nombre_calle_cliente"
               maxlength="50"
@@ -516,6 +519,7 @@
             <label for="numero_interior_cliente">Número Interior</label>
             <input
               pInputText
+              appUppercase
               formControlName="numero_interior_cliente"
               id="numero_interior_cliente"
               inputId="numero_interior_cliente"
@@ -527,6 +531,7 @@
             <label for="cruce_calles_cliente">Cruce de calles:</label>
             <input
               pInputText
+              appUppercase
               formControlName="cruce_calles_cliente"
               id="cruce_calles_cliente"
               aria-describedby="cruce_calles_cliente-help" />
@@ -535,6 +540,7 @@
             <label for="colonia_cliente">Colonia</label>
             <input
               pInputText
+              appUppercase
               id="colonia_cliente"
               aria-describedby="colonia_cliente-help"
               formControlName="colonia_cliente" />
@@ -549,6 +555,7 @@
             <label for="municipio_cliente">Municipio</label>
             <input
               pInputText
+              appUppercase
               formControlName="municipio_cliente"
               id="municipio_cliente"
               maxlength="50"
@@ -618,6 +625,7 @@
             >
             <input
               pInputText
+              appUppercase
               formControlName="referencias_dom_cliente"
               id="referencias_dom_cliente"
               aria-describedby="referencias_dom_cliente-help" />
@@ -697,7 +705,7 @@
               <input
                 formControlName="nombre_aval"
                 pInputText
-                oninput="this.value = this.value.toUpperCase()"
+                appUppercase
                 id="nombre_aval"
                 maxlength="50"
                 aria-describedby="nombre_aval-help" />
@@ -713,7 +721,7 @@
               <input
                 formControlName="apellido_paterno_aval"
                 pInputText
-                oninput="this.value = this.value.toUpperCase()"
+                appUppercase
                 id="apellido_paterno_aval"
                 maxlength="50"
                 aria-describedby="apellido_paterno_aval-help" />
@@ -729,7 +737,7 @@
               <input
                 formControlName="apellido_materno_aval"
                 pInputText
-                oninput="this.value = this.value.toUpperCase()"
+                appUppercase
                 id="apellido_materno_aval"
                 maxlength="50"
                 aria-describedby="apellido_materno_aval-help" />
@@ -805,6 +813,7 @@
               <label for="correo_electronico_aval">Correo electronico</label>
               <input
                 pInputText
+                appUppercase
                 formControlName="correo_electronico_aval"
                 id="correo_electronico_aval"
                 maxlength="100"
@@ -820,6 +829,7 @@
               <label for="ocupacion_aval">Ocupación</label>
               <input
                 pInputText
+                appUppercase
                 formControlName="ocupacion_aval"
                 id="ocupacion_aval"
                 maxlength="50"
@@ -899,6 +909,7 @@
               <label for="nombre_calle_aval">Nombre de la calle</label>
               <input
                 pInputText
+                appUppercase
                 formControlName="nombre_calle_aval"
                 id="nombre_calle_aval"
                 maxlength="50"
@@ -932,6 +943,7 @@
               <label for="numero_interior_aval">Número Interior</label>
               <input
                 pInputText
+                appUppercase
                 formControlName="numero_interior_aval"
                 id="numero_interior_aval"
                 inputId="numero_interior_aval"
@@ -943,6 +955,7 @@
               <label for="cruce_calles_aval">Cruce de calles:</label>
               <input
                 pInputText
+                appUppercase
                 formControlName="cruce_calles_aval"
                 id="cruce_calles_aval"
                 aria-describedby="cruce_calles_aval-help" />
@@ -951,6 +964,7 @@
               <label for="colonia_aval">Colonia</label>
               <input
                 pInputText
+                appUppercase
                 id="colonia_aval"
                 aria-describedby="colonia_aval-help"
                 formControlName="colonia_aval" />
@@ -965,6 +979,7 @@
               <label for="municipio_aval">Municipio</label>
               <input
                 pInputText
+                appUppercase
                 formControlName="municipio_aval"
                 id="municipio_aval"
                 maxlength="50"
@@ -1030,6 +1045,7 @@
               >
               <input
                 pInputText
+                appUppercase
                 formControlName="referencias_dom_aval"
                 id="referencias_dom_aval"
                 aria-describedby="referencias_dom_aval-help" />
@@ -1103,6 +1119,7 @@
           <label for="observaciones">Añadir observaciones</label>
           <textarea
             formControlName="observaciones"
+            appUppercase
             rows="5"
             cols="30"
             autoResize="true"
@@ -1209,6 +1226,6 @@
     <!-- <i class="pi pi-spin pi-cog" style="font-size: 2rem"></i> -->
   }
 </p-dialog>
-<!-- <pre>{{ mainForm.value | json }}</pre> -->
-<!-- <pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre> -->
-<!-- <pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre> -->
+<pre>{{ mainForm.value | json }}</pre>
+<pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre>
+<pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre>

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -1226,6 +1226,6 @@
     <!-- <i class="pi pi-spin pi-cog" style="font-size: 2rem"></i> -->
   }
 </p-dialog>
-<pre>{{ mainForm.value | json }}</pre>
-<pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre>
-<pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre>
+<!-- <pre>{{ mainForm.value | json }}</pre> -->
+<!-- <pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre> -->
+<!-- <pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre> -->

--- a/src/app/shared/directives/uppercase.directive.ts
+++ b/src/app/shared/directives/uppercase.directive.ts
@@ -1,0 +1,24 @@
+import { Directive, HostListener, inject } from '@angular/core';
+import { NgControl } from '@angular/forms';
+
+@Directive({
+  selector: '[appUppercase]',
+  standalone: true
+})
+export class UppercaseDirective {
+
+  private control = inject(NgControl);
+
+  @HostListener('input', ['$event'])
+  onInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+
+    const start = input.selectionStart;
+    const end = input.selectionEnd;
+
+    input.value = input.value.toUpperCase();
+    input.setSelectionRange(start, end);
+
+    this.control.control?.setValue(input.value, { emitEvent: false });
+  }
+}


### PR DESCRIPTION
# Cambio principal
Ahora todos los inputs de texto (que no acepten solo numeros, porque no tiene caso en esos) son convertidos a mayusculas tanto en el template como en el formulario. Esto se realizo con una directiva con la finalidad de reutilizarla en futuros cambios/implementaciones, la directiva se usa en el template con el nombre: **_appUppercase_**

Imagen con los inputs en mayusculas, aplica para todo el formulario, con algunas excepciones, como el campo de la url de gmaps:

<img width="743" height="490" alt="image" src="https://github.com/user-attachments/assets/b7b4278f-147b-4102-a5a2-b4172cfee235" />

## Correcciones
Esto tambien se le agrego al componente de busqueda de clientes/avales, al cual se se agrego tambien el mostrar el mensaje de error de "formato invalido" cuando se coloca un curp a buscar, para hacerlo mas intuitivo para el usuario, de lo contrario solo el contorno se ponia rojo, y se se hacia submit mostraba el error de que no cumplia con el regex, algo que es criptico para el usuario.

Imagen de emplo del nuevo mensaje de error para el curp en el componente de busqueda de clientes/avales, notese que se corrigio el css quedando mejor para busquedas tanto en desktop como movil:

<img width="752" height="247" alt="image" src="https://github.com/user-attachments/assets/b5240ad0-de1c-49e0-8dd4-51f875e22abc" />

El label del boton ya es dinamico, para indicar si se busca cliente o aval.

## Resuelve el issue
#92 