### PR TITLE
fix: input value event change

### DIFF
--- a/src/app/request-list/request-list.component.html
+++ b/src/app/request-list/request-list.component.html
@@ -17,10 +17,13 @@
           size="small"
           (onClick)="changeSearchTerm()"></p-button>
         <input
+          #searchInput
           type="text"
           id="search"
           pInputText
-          [(ngModel)]="searchInputValue"
+          autocomplete="off"
+          autocorrect="off"
+          spellcheck="false"
           [placeholder]="searchTerm"
           (keypress)="inputSearch($event)"
           class="w-11rem md:w-auto" />

--- a/src/app/request-list/request-list.component.ts
+++ b/src/app/request-list/request-list.component.ts
@@ -294,7 +294,6 @@ export class RequestListComponent implements OnInit {
 
   inputSearch(event: KeyboardEvent | MouseEvent) {
     const inputSearchValue = this.searchInput().nativeElement.value;
-    console.log({ inputSearchValue });
     if (event instanceof KeyboardEvent) {
       if (event.code !== 'Enter') return;
     }

--- a/src/app/request-list/request-list.component.ts
+++ b/src/app/request-list/request-list.component.ts
@@ -3,6 +3,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  ElementRef,
   inject,
   OnInit,
   signal,
@@ -72,6 +73,7 @@ export class RequestListComponent implements OnInit {
   fechaDropdown = viewChild<Dropdown>('fechaDropdown');
   cantidadDropdown = viewChild<Dropdown>('cantidadDropdown');
   statusDropdown = viewChild<Dropdown>('statusDropdown');
+  searchInput = viewChild.required<ElementRef<HTMLInputElement>>('searchInput');
   requests = signal<Requests[]>([]);
   requestUserList = signal<User[]>([]);
   groups = signal<Groups[]>([]);
@@ -83,7 +85,6 @@ export class RequestListComponent implements OnInit {
   selectedOrdenFecha: any = null;
   selectedOrdenCantidad: any = null;
   selectedStatus: any = null;
-  searchInputValue = '';
   searchTerm: 'cliente' | 'folio' = 'cliente';
   searchTermIcon: string = 'pi pi-user';
   showLoadingModal = false;
@@ -292,24 +293,24 @@ export class RequestListComponent implements OnInit {
   }
 
   inputSearch(event: KeyboardEvent | MouseEvent) {
+    const inputSearchValue = this.searchInput().nativeElement.value;
+    console.log({ inputSearchValue });
     if (event instanceof KeyboardEvent) {
       if (event.code !== 'Enter') return;
     }
-    if (this.searchInputValue.length < 1) return;
+    if (inputSearchValue.length < 1) return;
     this.showLoadingModal = true;
     if (this.searchTerm === 'cliente') {
-      const nombreCliente = this.searchInputValue;
       this.getRequestListItems({
         offSetRows: this.first,
         fetchRowsNumber: this.rows,
-        nombreCliente,
+        nombreCliente: inputSearchValue,
       });
     } else {
-      const folio = this.searchInputValue;
       this.getRequestListItems({
         offSetRows: this.first,
         fetchRowsNumber: this.rows,
-        folio,
+        folio: inputSearchValue,
       });
     }
   }


### PR DESCRIPTION
Se hizo un cambio para no depender del comportamiento de ngModel y confiar que el valor que el usuario coloque con teclados de telefonos moviles no llenen de basura el input en memoria, por ejemplo con el autocorrector y el autocompletado, ahora se toma el valor directamente de la referencia del html para no depender del ciclo de eventos de angular + teclados de telefonos moviles