### PR TITLE
Fecha inicial

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yoox-web-app",
-  "version": "0.0.0",
+  "version": "1.0.1",
   "scripts": {
     "ng": "ng",
     "env": "node ./scripts/set-env.js",

--- a/src/app/loan-request/loan-request.module.ts
+++ b/src/app/loan-request/loan-request.module.ts
@@ -23,6 +23,7 @@ import { StepperModule } from 'primeng/stepper';
 import { TableModule } from 'primeng/table';
 import { ToastModule } from 'primeng/toast';
 import { TooltipModule } from 'primeng/tooltip';
+import { CheckboxModule } from 'primeng/checkbox';
 
 import { BusquedaClientesComponent } from './components/busqueda-clientes/busqueda-clientes.component';
 import { ListS3FilesComponent } from './components/list-s3-files/list-s3-files.component';
@@ -62,6 +63,7 @@ import { UppercaseDirective } from '../shared/directives/uppercase.directive';
     CardModule,
     RefinanceSearchComponent,
     UppercaseDirective,
+    CheckboxModule,
   ],
   providers: [ConfirmationService, MessageService],
 })

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -101,15 +101,16 @@
               [showIcon]="true"
               [touchUI]="true"
               (onSelect)="calculaDiaDeLaSemana($event)"
-              dataType="string"
               dateFormat="dd/mm/yy"
               readonlyInput="true"
               [style]="{ width: '100%' }" />
             <p-checkbox
               class="mt-1"
-              label="Elegir fecha"
-              [binary]="true"
-              (onChange)="setCustomLoanDate()" />
+              label="Elegir fecha inicial"
+              [(ngModel)]="disabledCalendar"
+              [ngModelOptions]="{ standalone: true }"
+              binary="true"
+              (onChange)="setCustomLoanDate($event)" />
           </div>
 
           <!-- inicio valores calculados -->

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -405,7 +405,7 @@
               appUppercase
               formControlName="ocupacion_cliente"
               id="ocupacion_cliente"
-              maxlength="50"
+              maxlength="200"
               aria-describedby="ocupacion_cliente-help" />
           </div>
           <div class="col-12 sm:col-6 flex flex-column">
@@ -833,7 +833,7 @@
                 appUppercase
                 formControlName="ocupacion_aval"
                 id="ocupacion_aval"
-                maxlength="50"
+                maxlength="200"
                 aria-describedby="ocupacion_aval-help" />
             </div>
             <div class="col-12 sm:col-6 flex flex-column">

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -99,17 +99,17 @@
               placeholder="dd/mm/aaaa"
               [iconDisplay]="'input'"
               [showIcon]="true"
-              [showButtonBar]="true"
+              [touchUI]="true"
               (onSelect)="calculaDiaDeLaSemana($event)"
+              dataType="string"
               dateFormat="dd/mm/yy"
               readonlyInput="true"
               [style]="{ width: '100%' }" />
-            <small
-              id="fecha_inicial-help"
-              class="mb-2 text-red-500"
-              [hidden]="hideField('fecha_inicial')"
-              >Fecha Inicial requerida</small
-            >
+            <p-checkbox
+              class="mt-1"
+              label="Elegir fecha"
+              [binary]="true"
+              (onChange)="setCustomLoanDate()" />
           </div>
 
           <!-- inicio valores calculados -->
@@ -1226,6 +1226,6 @@
     <!-- <i class="pi pi-spin pi-cog" style="font-size: 2rem"></i> -->
   }
 </p-dialog>
-<!-- <pre>{{ mainForm.value | json }}</pre> -->
-<!-- <pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre> -->
-<!-- <pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre> -->
+<pre>{{ mainForm.value | json }}</pre>
+<pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre>
+<pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre>

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -1227,6 +1227,6 @@
     <!-- <i class="pi pi-spin pi-cog" style="font-size: 2rem"></i> -->
   }
 </p-dialog>
-<pre>{{ mainForm.value | json }}</pre>
-<pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre>
-<pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre>
+<!-- <pre>{{ mainForm.value | json }}</pre> -->
+<!-- <pre>Errores FormCliente: {{ mainForm.get('formCliente')?.errors | json }}</pre> -->
+<!-- <pre>Errores FormAval: {{ mainForm.get('formAval')?.errors | json }}</pre> -->

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -65,6 +65,7 @@ import { AddressService } from '../../services/adress.service';
 import { Refinance } from '../../components/refinance-search/types/refinance';
 import { Stepper } from 'primeng/stepper';
 import { Guarantor } from '../../types/searchCustomers.interface';
+import { CheckboxChangeEvent } from 'primeng/checkbox';
 
 @Component({
   selector: 'app-loan',
@@ -111,11 +112,11 @@ export class LoanComponent implements OnDestroy, OnInit {
   semanasDePlazo: number | undefined;
   id_plazo: number | undefined;
   semana_refinanciamiento: string | undefined = '';
-  fecha_inicial: Date | undefined;
+  fecha_inicial: Date | undefined | '';
   fecha_final_estimada: Date | undefined;
   fecha_final_estimada_string: string | null = null;
-  fechaMinima: Date = new Date();
-  dia_semana: string | null = null;
+  fechaMinima: Date | undefined | '' = new Date();
+  dia_semana: string | null = days[0];
   days: string[] = days;
   cantidadIngresada: number = this.minLoanAmount;
   tasa_interes: number = 0;
@@ -154,7 +155,7 @@ export class LoanComponent implements OnDestroy, OnInit {
     formName: string;
     inputRef: InputNumber;
   };
-  disabledCalendar = true;
+  disabledCalendar = false;
 
   constructor() {
     this.mainForm = this.formInit();
@@ -206,9 +207,7 @@ export class LoanComponent implements OnDestroy, OnInit {
         [Validators.required, Validators.min(this.minLoanAmount)],
       ],
       plazo: ['', Validators.required],
-      fecha_inicial: [
-        { value: new Date().toLocaleDateString('es-MX'), disabled: true },
-      ],
+      fecha_inicial: [{ value: new Date(), disabled: true }],
       observaciones: [''],
       formCliente: this.#formBuilder.group(
         {
@@ -698,7 +697,9 @@ export class LoanComponent implements OnDestroy, OnInit {
           this.closedDate = data.closed_date!;
           this.tasa_interes = data.tasa_de_interes;
           this.cantidadIngresada = data.cantidad_prestada;
-          this.fecha_inicial = new Date(data.fecha_inicial.replace(/Z$/, ''));
+          this.fecha_inicial =
+            data.fecha_inicial &&
+            new Date(data.fecha_inicial.replace(/Z$/, ''));
           this.fechaMinima = this.fecha_inicial;
           this.customerFolderName = `${this.loanRequestId}-${data.apellido_paterno_cliente.toUpperCase()}`;
           this.nombre_agente = data.nombre_agente;
@@ -789,9 +790,13 @@ export class LoanComponent implements OnDestroy, OnInit {
             },
           });
           this.calculaFechaFinal();
-          this.calculaDiaDeLaSemana(
-            new Date(data.fecha_inicial.replace(/Z$/, ''))
-          );
+          if (data.fecha_inicial) {
+            this.calculaDiaDeLaSemana(
+              new Date(data.fecha_inicial.replace(/Z$/, ''))
+            );
+            this.disabledCalendar = true;
+            this.mainForm.get('fecha_inicial')?.enable();
+          }
           this.updateAmountValidator(
             data.cantidad_prestada,
             data.cantidad_restante
@@ -1060,9 +1065,10 @@ export class LoanComponent implements OnDestroy, OnInit {
       });
   }
 
-  setCustomLoanDate() {
-    this.disabledCalendar = !this.disabledCalendar;
-    if (this.disabledCalendar) this.mainForm.get('fecha_inicial')?.disable();
-    else this.mainForm.get('fecha_inicial')?.enable();
+  setCustomLoanDate(event: CheckboxChangeEvent) {
+    this.disabledCalendar = event.checked;
+    if (this.disabledCalendar) this.mainForm.get('fecha_inicial')?.enable();
+    else this.mainForm.get('fecha_inicial')?.disable();
+    this.calculaDiaDeLaSemana(this.mainForm.get('fecha_inicial')?.value);
   }
 }

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -117,7 +117,7 @@ export class LoanComponent implements OnDestroy, OnInit {
   fechaMinima: Date = new Date();
   dia_semana: string | null = null;
   days: string[] = days;
-  cantidadIngresada: number = 0;
+  cantidadIngresada: number = this.minLoanAmount;
   tasa_interes: number = 0;
   cantidad_pagar: number = 0;
   pagoSemanal: number | null = null;
@@ -154,6 +154,7 @@ export class LoanComponent implements OnDestroy, OnInit {
     formName: string;
     inputRef: InputNumber;
   };
+  disabledCalendar = true;
 
   constructor() {
     this.mainForm = this.formInit();
@@ -205,7 +206,9 @@ export class LoanComponent implements OnDestroy, OnInit {
         [Validators.required, Validators.min(this.minLoanAmount)],
       ],
       plazo: ['', Validators.required],
-      fecha_inicial: ['', Validators.required],
+      fecha_inicial: [
+        { value: new Date().toLocaleDateString('es-MX'), disabled: true },
+      ],
       observaciones: [''],
       formCliente: this.#formBuilder.group(
         {
@@ -1055,5 +1058,11 @@ export class LoanComponent implements OnDestroy, OnInit {
         detail: 'No se puede abrir la ubicación.',
         life: 3000,
       });
+  }
+
+  setCustomLoanDate() {
+    this.disabledCalendar = !this.disabledCalendar;
+    if (this.disabledCalendar) this.mainForm.get('fecha_inicial')?.disable();
+    else this.mainForm.get('fecha_inicial')?.enable();
   }
 }

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -207,7 +207,9 @@ export class LoanComponent implements OnDestroy, OnInit {
         [Validators.required, Validators.min(this.minLoanAmount)],
       ],
       plazo: ['', Validators.required],
-      fecha_inicial: [{ value: new Date(), disabled: true }],
+      fecha_inicial: [
+        { value: this.generateLocalISOStringDate(), disabled: true },
+      ],
       observaciones: [''],
       formCliente: this.#formBuilder.group(
         {
@@ -697,9 +699,9 @@ export class LoanComponent implements OnDestroy, OnInit {
           this.closedDate = data.closed_date!;
           this.tasa_interes = data.tasa_de_interes;
           this.cantidadIngresada = data.cantidad_prestada;
-          this.fecha_inicial =
-            data.fecha_inicial &&
-            new Date(data.fecha_inicial.replace(/Z$/, ''));
+          this.fecha_inicial = data.fecha_inicial
+            ? new Date(data.fecha_inicial.replace(/Z$/, ''))
+            : this.generateLocalISOStringDate();
           this.fechaMinima = this.fecha_inicial;
           this.customerFolderName = `${this.loanRequestId}-${data.apellido_paterno_cliente.toUpperCase()}`;
           this.nombre_agente = data.nombre_agente;
@@ -1070,5 +1072,13 @@ export class LoanComponent implements OnDestroy, OnInit {
     if (this.disabledCalendar) this.mainForm.get('fecha_inicial')?.enable();
     else this.mainForm.get('fecha_inicial')?.disable();
     this.calculaDiaDeLaSemana(this.mainForm.get('fecha_inicial')?.value);
+  }
+
+  generateLocalISOStringDate() {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return new Date(`${year}-${month}-${day}T00:00:00.000`);
   }
 }

--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -116,7 +116,7 @@ export class LoanComponent implements OnDestroy, OnInit {
   fecha_final_estimada: Date | undefined;
   fecha_final_estimada_string: string | null = null;
   fechaMinima: Date | undefined | '' = new Date();
-  dia_semana: string | null = days[0];
+  dia_semana: string | null = '';
   days: string[] = days;
   cantidadIngresada: number = this.minLoanAmount;
   tasa_interes: number = 0;
@@ -595,7 +595,7 @@ export class LoanComponent implements OnDestroy, OnInit {
       user_role: this.currentUser.ROL,
       id_grupo_original: this.id_grupo_original || this.currentUser.ID_GRUPO,
       fecha_final_estimada: this.fecha_final_estimada,
-      dia_semana: this.dia_semana,
+      ...(this.dia_semana ? { dia_semana: this.dia_semana } : {}),
       cantidad_pagar: this.cantidad_pagar,
       id_loan_to_refinance: this.refinanceResults()?.id_prestamo,
     };

--- a/src/app/loan-request/types/loan-request.interface.ts
+++ b/src/app/loan-request/types/loan-request.interface.ts
@@ -91,8 +91,8 @@ export interface LoanRequest {
   id_plazo: number;
   cantidad_prestada: number;
   dia_semana: string;
-  fecha_inicial: string;
-  fecha_final_estimada: Date;
+  fecha_inicial?: string;
+  fecha_final_estimada?: Date;
   cantidad_pagar: number;
   tasa_de_interes: number;
   observaciones: string;


### PR DESCRIPTION
# Fecha inicial

## Task relacionado
resolves #88 

## Descripcion
Hay un nuevo checkbox debajo del campo de fecha inicial, este campo puede estar presente o no en la solicitud, y determina cuando se inicia el prestamo, si por una fecha seleccionada por el usuario o por el propio sistema cuando la solicitud es aprobada

Tambien se hicieron correcciones varias como por ejemplo:
- Se extendio de 50 a 200 el limite de caracteres para los campos de ocupacion para clientes y avales (de momento el campo visualmente no se ha agrandado, el cambio es solo para la cantidad de caracteres permitidos)
- Se agrego la version 1.0.1 como numero de version, antes estaba solo en 0.0.0, de momento los cambios se haran de manera manual en cada deploy, pero se automatizara con un paquete de npm al ejecutarse los github actions. El numero es visible en el menu principal debajo del boton de cerrar session
- Se hizo un cambio visual y un refactor de codigo al componente de busqueda de clientes/avales existentes, ya no tienen valores incorrectos de CSS y ahora se ve mucho mas estetico, tambien el label de busqueda dentro de este componente es dinamico para que sea mas claro que es lo que se esta buscando

### Imagenes
<img width="775" height="263" alt="image" src="https://github.com/user-attachments/assets/9eb48938-31d1-4711-bb76-054bdc9ec649" />
<img width="273" height="151" alt="image" src="https://github.com/user-attachments/assets/d6d67b07-b28e-4694-8c8b-a1f5979670bc" />
<img width="752" height="288" alt="image" src="https://github.com/user-attachments/assets/5afbc367-69a1-46bc-9dce-ee1e4ac6cdcf" />
