### PR TITLE
Campo ocupacion

### DIFF
--- a/src/app/dashboard/services/desktop-app.service.ts
+++ b/src/app/dashboard/services/desktop-app.service.ts
@@ -11,9 +11,14 @@ const DEFAULT_DESKTOP_APP_URL =
 export class DesktopAppService {
   private http = inject(HttpClient);
   private baseUrl = environment.API_URL;
+  private token = localStorage.getItem('token');
   private desktopAppResponse = toSignal(
     this.http
-      .get<{ url: string }>(`${this.baseUrl}desktop-app-url`)
+      .get<{
+        url: string;
+      }>(`${this.baseUrl}desktop-app-url`, {
+        headers: { authorization: `${this.token}` },
+      })
       .pipe(catchError(() => of({ url: DEFAULT_DESKTOP_APP_URL }))),
     { initialValue: { url: DEFAULT_DESKTOP_APP_URL } }
   );

--- a/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.ts
+++ b/src/app/loan-request/components/busqueda-clientes/busqueda-clientes.component.ts
@@ -254,7 +254,6 @@ export class BusquedaClientesComponent {
       next: (foundCustomers: Customer[]) => {
         this.loading.set(false);
         this.clientesEncontrados.set(foundCustomers);
-        console.log(foundCustomers);
       },
       error: ({ error, errorMessage, errorType }) => {
         this.loading.set(false);

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -403,7 +403,7 @@
             <textarea
               appUppercase
               formControlName="ocupacion_cliente"
-              rows="1"
+              rows="3"
               cols="30"
               autoResize="true"
               maxlength="200"
@@ -834,7 +834,7 @@
               <textarea
                 appUppercase
                 formControlName="ocupacion_aval"
-                rows="1"
+                rows="3"
                 cols="30"
                 autoResize="true"
                 maxlength="200"

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -400,13 +400,16 @@
           </div>
           <div class="col-12 sm:col-6 flex flex-column">
             <label for="ocupacion_cliente">Ocupación</label>
-            <input
-              pInputText
+            <textarea
               appUppercase
               formControlName="ocupacion_cliente"
-              id="ocupacion_cliente"
+              rows="4"
+              cols="30"
+              autoResize="true"
               maxlength="200"
-              aria-describedby="ocupacion_cliente-help" />
+              pInputTextarea
+              id="ocupacion_cliente">
+            </textarea>
           </div>
           <div class="col-12 sm:col-6 flex flex-column">
             <label for="curp_cliente">CURP (Sólo Mayusculas y numeros)</label>
@@ -828,13 +831,16 @@
             </div>
             <div class="col-12 sm:col-6 flex flex-column">
               <label for="ocupacion_aval">Ocupación</label>
-              <input
-                pInputText
+              <textarea
                 appUppercase
                 formControlName="ocupacion_aval"
-                id="ocupacion_aval"
+                rows="4"
+                cols="30"
+                autoResize="true"
                 maxlength="200"
-                aria-describedby="ocupacion_aval-help" />
+                pInputTextarea
+                id="ocupacion_aval">
+              </textarea>
             </div>
             <div class="col-12 sm:col-6 flex flex-column">
               <label for="curp_aval">CURP (Sólo Mayusculas y numeros)</label>

--- a/src/app/loan-request/pages/loan/new-loan.component.html
+++ b/src/app/loan-request/pages/loan/new-loan.component.html
@@ -403,7 +403,7 @@
             <textarea
               appUppercase
               formControlName="ocupacion_cliente"
-              rows="4"
+              rows="1"
               cols="30"
               autoResize="true"
               maxlength="200"
@@ -834,7 +834,7 @@
               <textarea
                 appUppercase
                 formControlName="ocupacion_aval"
-                rows="4"
+                rows="1"
                 cols="30"
                 autoResize="true"
                 maxlength="200"


### PR DESCRIPTION
# Descripcion
Ahora el campo de ocupacion, tanto de cliente como aval se cambio de un input clasico por un textarea, permitiendo que el componente aumente de tamaño vertical cuando necesita mostrar mas texto, limitado a 200 caracteres. resolves #90 

Originalmente se habia mencionado que se moveria a la parte inferior de su respectiva seccion, pero no fue necesario ya que el comportamiento colocado al textarea es suficientemente bueno y no rompe el CSS del resto del formulario, por lo cual no le vi necesidad de movelo abajo, así se preserva el contexto semantico por sección para los datos de la persona.

## Captura en pantallas grandes:
<img width="746" height="612" alt="image" src="https://github.com/user-attachments/assets/d9d0a637-954c-4e68-9700-8a697bcc16a7" />

## Captura en moviles:
<img width="372" height="904" alt="image" src="https://github.com/user-attachments/assets/2f002af2-3829-4bea-bd95-8a9e727d957d" />
