### PR TITLE
chore: asignacion de busqueda id domicilio

### DIFF
--- a/src/app/loan-request/pages/loan/new-loan.component.ts
+++ b/src/app/loan-request/pages/loan/new-loan.component.ts
@@ -645,9 +645,11 @@ export class LoanComponent implements OnDestroy, OnInit {
     this.mainForm.patchValue({
       formCliente: {
         id_domicilio_cliente: searchResults.id_domicilio_cliente,
+        isCustomerAddressUpdate: true,
       },
       formAval: {
         id_domicilio_aval: searchResults.id_domicilio_aval,
+        isGuarantorAddressUpdate: true,
       },
     });
   }
@@ -662,6 +664,7 @@ export class LoanComponent implements OnDestroy, OnInit {
     this.mainForm.patchValue({
       formAval: {
         id_domicilio_aval: searchResults.id_domicilio,
+        isGuarantorAddressUpdate: true,
       },
     });
   }
@@ -1133,6 +1136,7 @@ export class LoanComponent implements OnDestroy, OnInit {
       console.log('Plazos no son iguales');
       return false;
     }
+
     return true;
   }
 


### PR DESCRIPTION
se agrega un true al campo del formulario cuando se busca y se selecciona correctamente el checkbox de id de domicilio en la logica de busqueda de clientes/avales